### PR TITLE
Handle invalid field in decodeIntoArray

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -75,7 +75,7 @@ type LivesInRequiredArray struct {
 }
 
 type RequiredBasicTypes struct {
-	Age int
+	Age  int
 	Name string
 	Lost bool
 }
@@ -96,7 +96,6 @@ func MyTestFactory(kind string) (interface{}, error) {
 	}
 	return f(), nil
 }
-
 
 func TestDecodeNestedObject(t *testing.T) {
 
@@ -443,6 +442,11 @@ func TestDecodeNestedObject(t *testing.T) {
 		_, err := decode.UnmarshalJSONInto([]byte(b), i, SchemaPathFactory)
 		So(err, ShouldNotBeNil)
 		_, err = decode.UnmarshalJSONInto([]byte(b), &i, SchemaPathFactory)
+		So(err, ShouldNotBeNil)
+	})
+	Convey("Test OneOf decoding - invalid oneOf field kind", t, func() {
+		b := `{ "name": "john", "livesIn": [] }`
+		_, err := decode.UnmarshalJSONInto([]byte(b), &PetOwner{}, SchemaPathFactory)
 		So(err, ShouldNotBeNil)
 	})
 }

--- a/decode/decoder.go
+++ b/decode/decoder.go
@@ -207,8 +207,10 @@ func decodeIntoArray(field reflect.Value, iter iterator, len int, pf PathFactory
 	} else if field.Kind() == reflect.Slice {
 		s = reflect.MakeSlice(field.Type(), len, len)
 		et = field.Type().Elem()
+	} else {
+		return fmt.Errorf("Invalid field")
 	}
-	
+
 	i := 0
 	for next, o := iter(); next != nil; next, o = next() {
 		pV := reflect.ValueOf(o)
@@ -275,7 +277,7 @@ func decodeIntoObjectField(field reflect.Value, _ string, v map[string]interface
 	} else {
 		pV = reflect.New(field.Type()).Interface()
 	}
-	
+
 	child, err := DecodeInto(v, pV, pf)
 	if err != nil {
 		return err


### PR DESCRIPTION
Problem: Passing an invalid field (an empty array where there should be a struct) as a part of a request to DecodeInto was causing a panic in decodeIntoArray.

Solution: As a part of the block that checks the field.Kind() type, if none of the three types is discovered, an error string is returned so that it gets handled, rather than panicking on a nil value later on. 

Testing (optional if not described in Solution section): A unit test mimicking this issue has been added to decode_test.go 
