### PR TITLE
Add method to parse underlying type into object

### DIFF
--- a/decode/decoder.go
+++ b/decode/decoder.go
@@ -159,7 +159,11 @@ func DecodeInto(m map[string]interface{}, o interface{}, pf PathFactory) (interf
 			nV := reflect.New(ft)
 
 			if !vV.Type().ConvertibleTo(ft) {
-				return nil, fmt.Errorf("cannot convert value (%v) to field '%s' type\n", v, fldName)
+				err := parseAndSetField(fldName, field, nV, vV)
+				if err != nil {
+					return nil, err
+				}
+				continue
 			}
 			nV.Elem().Set(vV.Convert(ft))
 			field.Set(nV.Elem().Addr())
@@ -339,4 +343,24 @@ func UnmarshalJSONInto(b []byte, o interface{}, pf PathFactory) (interface{}, er
 		return nil, err
 	}
 	return DecodeInto(m, o, pf)
+}
+
+func parseAndSetField(path string, field, newField, val reflect.Value) error {
+	unmarshaler, ok := newField.Interface().(json.Unmarshaler)
+	if ok {
+		// marshal val back to []byte since it was converted to some underlying type (int/string)
+		valBytes, err := json.Marshal(val.Interface());
+		if err != nil {
+			return fmt.Errorf("Cannot convert value to []byte when attempting to set '%s': %s", path, err) 
+		}
+		// unmarshal valBytes back into newField object via the unmarshaler
+		err = unmarshaler.UnmarshalJSON(valBytes)
+		if err != nil {
+			return fmt.Errorf("Cannot unmarshal byte values for field '%s': %s", path, err)
+		}
+		// set field to the value unmarshaled into newField
+		field.Set(newField)
+		return nil
+	}
+	return fmt.Errorf("cannot convert value (%v) to field '%s' type", val, path)
 }


### PR DESCRIPTION
Problem: Certain items in an API schema were defined as strings but are converted into a typed struct upon code generation of the schema models. When decoding these strings on requests/responses, go-decode failed to be able to convert them back into the defined type. 

Solution: This PR proposes a function for, if finding the inability to convert the types, checking if a field has access to an unmarshaler. If so, it re-marshals the value and then unmarshals them back into the type, letting the associated library take care of all particular parsing details. It then is able to set the field to the correct value.  

Testing (optional if not described in Solution section): A unit test has been added to demonstrate this issue and ensure it is covered. 
