### PR TITLE
Deref pointers for required slices in all cases + unit test

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -74,6 +74,16 @@ type LivesInRequiredArray struct {
 	LivesIn []string
 }
 
+type LivesInRequiredArrayNested struct {
+	Name    string
+	LivesIn []RequiredBasicTypes
+}
+
+type LivesInArrayOfPointers struct {
+	Name    string
+	LivesIn []*string
+}
+
 type RequiredBasicTypes struct {
 	Age  int
 	Name string
@@ -428,6 +438,22 @@ func TestDecodeNestedObject(t *testing.T) {
 		i, err := decode.UnmarshalJSONInto([]byte(b), &x, SchemaPathFactory)
 		So(err, ShouldBeNil)
 		So(i.(*LivesInRequiredArray), ShouldResemble, &LivesInRequiredArray{LivesIn: []string{"class", "Palace"}})
+	})
+	Convey("Test OneOf decoding - can decode into object that has required array with nested object", t, func() {
+		x := LivesInRequiredArrayNested{}
+		b := `{ "livesIn": [ { "age":7, "name": "spot", "lost": false } ] }`
+		i, err := decode.UnmarshalJSONInto([]byte(b), &x, SchemaPathFactory)
+		So(err, ShouldBeNil)
+		So(i.(*LivesInRequiredArrayNested), ShouldResemble, &LivesInRequiredArrayNested{LivesIn: []RequiredBasicTypes{{Age: 7, Name: "spot", Lost: false}}})
+	})
+	Convey("Test OneOf decoding - can decode into object that has an array of pointers", t, func() {
+		x := LivesInArrayOfPointers{}
+		b := `{ "livesIn": [ "class", "Palace" ]}`
+		i, err := decode.UnmarshalJSONInto([]byte(b), &x, SchemaPathFactory)
+		So(err, ShouldBeNil)
+		string1 := "class"
+		string2 := "Palace"
+		So(i.(*LivesInArrayOfPointers), ShouldResemble, &LivesInArrayOfPointers{LivesIn: []*string{&string1, &string2}})
 	})
 	Convey("Test OneOf decoding - can decode into object that has required basic types", t, func() {
 		y := LivesInStruct{}


### PR DESCRIPTION
Fix: Check and handle compatibility of slice and value pointers when decoding into an array

Problem: decodeIntoArray was previously returning an error when attempting to decode into a required slice as the dereferencing in place was not covering all possible cases.  

Solution: This PR makes a more thorough check of whether the slice contains pointers and whether the value being assigned to it is a pointer. It should handle both cases where they are incompatible (a slice of pointers and a non-pointer value and a slice of values with a pointer value) so that conversion to pointer or setting into the address happens where necessary. This check also happens outside of the code block that only occurs if the slice has a nested object for decoding within it. 

Testing (optional if not described in Solution section): Two unit test cases have been added that would hit these special cases. 
