### PR TITLE
Add check and return error for nil value

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -494,4 +494,9 @@ func TestDecodeNestedObject(t *testing.T) {
 		_, err := decode.UnmarshalJSONInto([]byte(b), &TimedStruct{}, nil)
 		So(err, ShouldNotBeNil)
 	})
+	Convey("Test decoding -- cannot decode when field is set to null", t, func() {
+		b := `{ "livesIn" : { "age": 7, "name": null, "lost": false}}`
+		_, err := decode.UnmarshalJSONInto([]byte(b), &LivesInStruct{}, SchemaPathFactory)
+		So(err, ShouldNotBeNil)
+	})
 }

--- a/decode/decoder.go
+++ b/decode/decoder.go
@@ -150,6 +150,8 @@ func DecodeInto(m map[string]interface{}, o interface{}, pf PathFactory) (interf
 				return nil, e
 			}
 			continue
+		case nil:
+			return nil, fmt.Errorf("Invalid value: Null not allowed field '%v'", fldName)
 		}
 
 		// use reflection to set the field


### PR DESCRIPTION
Fix: Add nil check and return error on obj map value 

Problem: Decode was panicking if there was a nil value set for a field within the passed in object map when it went to call .Type() or .TypeOf() on lines 161 and 181. 

Solution: The a nil check is included in the v.(type) switch statement to ensure this value is actually set before moving on. This ensures an error is passed back rather than a panic. 

Testing (optional if not described in Solution section):  A unit test for this case has been included. 
