### PR TITLE
Ignore nil value for unrequired fields

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -96,7 +96,7 @@ type LivesInStruct struct {
 }
 
 type TimedStruct struct {
-	Name string
+	Name       string
 	UpdateTime *time.Time
 }
 
@@ -494,9 +494,15 @@ func TestDecodeNestedObject(t *testing.T) {
 		_, err := decode.UnmarshalJSONInto([]byte(b), &TimedStruct{}, nil)
 		So(err, ShouldNotBeNil)
 	})
-	Convey("Test decoding -- cannot decode when field is set to null", t, func() {
-		b := `{ "livesIn" : { "age": 7, "name": null, "lost": false}}`
-		_, err := decode.UnmarshalJSONInto([]byte(b), &LivesInStruct{}, SchemaPathFactory)
+	Convey("Test decoding -- cannot decode when required field is set to null", t, func() {
+		b := `{ "name": null, "updateTime": "2019-10-21T14:56:28.292468-06:00"}`
+		_, err := decode.UnmarshalJSONInto([]byte(b), &TimedStruct{}, SchemaPathFactory)
 		So(err, ShouldNotBeNil)
+	})
+	Convey("Test decoding -- allow decode when unrequired field is set to null", t, func() {
+		b := `{ "name": "john", "updateTime": null }`
+		i, err := decode.UnmarshalJSONInto([]byte(b), &TimedStruct{}, SchemaPathFactory)
+		So(err, ShouldBeNil)
+		So(i.(*TimedStruct), ShouldResemble, &TimedStruct{Name: "john"})
 	})
 }


### PR DESCRIPTION
Fix: Only return an error if a required field (non-pointer) has a nil value. 

Problem: After clarification, it was deemed best if a null value in an unrequired field (a pointer) is ignored while decoding. 

Solution: An additional check in the nil case of the switch statement of the field value has been added to see whether or not it is a pointer.
Also included in this MR are some basic formatting changes and newlines re-added to error messages that were removed in previous commits. 

Testing (optional if not described in Solution section):  The unit tests have been broken down to test both cases of null filled in for required and unrequired fields. 