### PR TITLE
feature: assign default values to decoded struct fields

### DIFF
--- a/decode/decode_cov_test.go
+++ b/decode/decode_cov_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 F5 Networks. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// The test here are meant to call functions that cannot be
+// called from outside the package in order to ensure coverage
+package decode
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// Test that fields for which there's no value in a payload are still set from defaults specified in struct tags
+// *Note* the tests here MUST match the contents of the tags specified in the struct variable up the top of the file
+func TestDefaultValues(t *testing.T) {
+
+	Convey("parsing Marshaller field succeeds", t, func() {
+		srcv := reflect.ValueOf(&time.Time{})
+		srcvp := reflect.PtrTo(srcv.Type())
+		pf := reflect.New(srcvp.Elem())
+
+		e := parseAndSetField("Time", pf.Elem(), reflect.ValueOf(&time.Time{}), reflect.ValueOf("2006-01-02T12:34:56Z"))
+		So(e, ShouldBeNil)
+	})
+
+	Convey("converting Marshaller fields with bad data fails", t, func() {
+		ci := make(chan int)
+		vum := reflect.ValueOf(&ci)
+		srct := time.Time{}
+		vumv := reflect.ValueOf(&srct)
+
+		_, e := convertUnmarshallerField("chan", vum, reflect.ValueOf(""))
+		So(e, ShouldNotBeNil)
+		_, e = convertUnmarshallerField("Time", vumv, vum)
+		So(e, ShouldNotBeNil)
+		e = parseAndSetField("Time", vumv, vumv, vum)
+		So(e, ShouldNotBeNil)
+	})
+
+	Convey("attempting to convert unsupported type from string should fail", t, func() {
+		ci := make(chan int)
+		_, e := convertFromString(reflect.TypeOf(ci), "")
+		So(e, ShouldNotBeNil)
+	})
+
+	Convey("attempting to use a convertible type as argument to check that type is not supported should fail", t, func() {
+		i := 1
+		e := unsupportedTypeForDefault(reflect.TypeOf(i))
+		So(e, ShouldNotBeNil)
+	})
+}

--- a/decode/decoder.go
+++ b/decode/decoder.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/iancoleman/strcase"
 )
@@ -20,6 +21,34 @@ type OneOfFactory func(map[string]interface{}) (interface{}, error)
 
 // PathFactory returns a Factory
 type PathFactory func(path string) (func(map[string]interface{}) (interface{}, error), error)
+
+// DefaultTagName specifies the struct tag used to identify default value for the field
+const DefaultTagName = "default"
+
+// UnmarshalJSON byte description of a Decodeable thing
+func UnmarshalJSON(b []byte, discriminator string, f Factory) (interface{}, error) {
+	m := make(map[string]interface{})
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+	return Decode(m, discriminator, f)
+}
+
+// UnmarshalJSON byte into an instance of object
+func UnmarshalJSONInto(b []byte, o interface{}, pf PathFactory) (interface{}, error) {
+	return UnmarshalJSONIntoWithDefaults(b, o, pf, false)
+}
+
+// UnmarshalJSON byte into an instance of object
+func UnmarshalJSONIntoWithDefaults(b []byte, o interface{}, pf PathFactory, applyDefaults bool) (interface{}, error) {
+	m := make(map[string]interface{})
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+	return decodeInto(m, o, pf, applyDefaults)
+}
 
 // Decode a map into a Decodeable thing given the discriminator and the factory for all possible
 // types and embedded types
@@ -100,53 +129,72 @@ func Decode(m map[string]interface{}, discriminator string, f Factory) (interfac
 	return r, nil
 }
 
-// Decode an object's attributes using DecoderDesc
 func DecodeInto(m map[string]interface{}, o interface{}, pf PathFactory) (interface{}, error) {
+	return decodeInto(m, o, pf, false)
+}
+
+func DecodeIntoWithDefaults(m map[string]interface{}, o interface{}, pf PathFactory, applyDefaults bool) (interface{}, error) {
+	return decodeInto(m, o, pf, applyDefaults)
+}
+
+// Decode an object's attributes using PathFactory
+func decodeInto(m map[string]interface{}, o interface{}, pf PathFactory, applyDefaults bool) (interface{}, error) {
+	vo := reflect.ValueOf(o)
+	to := vo.Type()
+	fm := map[string]reflect.StructField{}
 
 	// bail if the passed in object is not a struct
-	if reflect.TypeOf(o).Kind() != reflect.Ptr ||
-		(reflect.TypeOf(o).Elem().Kind() != reflect.Struct && reflect.TypeOf(o).Elem().Kind() != reflect.Slice) {
-		return nil, fmt.Errorf("Target object is not a struct/slice pointer. Unsupprted")
+	if to.Kind() != reflect.Ptr || (to.Elem().Kind() != reflect.Struct && to.Elem().Kind() != reflect.Slice) {
+		return nil, fmt.Errorf("Target object is not a struct/slice pointer. Unsupported")
 	}
 
-	objSchemaName := reflect.TypeOf(o).Elem().Name()
+	objSchemaName := to.Elem().Name()
 
+	// only scan struct fields if applyDefaults is specified
+	if applyDefaults {
+		for i := 0; i < vo.Elem().NumField(); i++ {
+			sf := to.Elem().Field(i)
+			fm[sf.Name] = sf
+		}
+	}
 	// for each field in the map, if the field is a OneOf (as described in dd), use the associated factory
 	for k, v := range m {
 
 		fldName := strcase.ToCamel(k)
-		field := reflect.ValueOf(o).Elem().FieldByName(fldName)
+		field := vo.Elem().FieldByName(fldName)
 
 		// ignore unknown fields
 		if !field.IsValid() {
 			continue
 		}
 
-		// decode regular fields, recursing into DecodeInto in case of object or array types
-		switch v.(type) {
+		// remove from field set
+		delete(fm, fldName)
+
+		// decode regular fields, recursing into decodeInto in case of object or array types
+		switch vt := v.(type) {
 		case map[string]interface{}:
 			// Decode a OneOf field and continue if it is
-			ok, e := decodeIntoOneOfField(field, fldName, objSchemaName, k, v.(map[string]interface{}), pf)
+			ok, e := decodeIntoOneOfField(field, fldName, objSchemaName, k, vt, pf, applyDefaults)
 			if e != nil {
 				return nil, e
 			}
-			if ok {
-				continue
+			if !ok {
+				if e := decodeIntoObjectField(field, fldName, vt, pf, applyDefaults); e != nil {
+					return nil, e
+				}
 			}
 
-			if e := decodeIntoObjectField(field, fldName, v.(map[string]interface{}), pf); e != nil {
-				return nil, e
-			}
 			continue
 
 		case []interface{}:
-			if e := decodeIntoArrayField(field, fldName, v.([]interface{}), pf); e != nil {
+			if e := decodeIntoArrayField(field, fldName, vt, pf, applyDefaults); e != nil {
 				return nil, e
 			}
 			continue
 
 		case []map[string]interface{}:
-			if e := decodeIntoArrayOfObjectsField(field, fldName, v.([]map[string]interface{}), pf); e != nil {
+			if e := decodeIntoArrayOfObjectsField(field, fldName, vt, pf, applyDefaults); e != nil {
 				return nil, e
 			}
 			continue
@@ -160,19 +208,9 @@ func DecodeInto(m map[string]interface{}, o interface{}, pf PathFactory) (interf
 
 		// use reflection to set the field
 		if field.Kind() == reflect.Ptr {
-			vV := reflect.ValueOf(v)
-			ft := reflect.TypeOf(field.Interface()).Elem()
-			nV := reflect.New(ft)
-
-			if !vV.Type().ConvertibleTo(ft) {
-				err := parseAndSetField(fldName, field, nV, vV)
-				if err != nil {
-					return nil, err
-				}
-				continue
+			if e := assignPtrField(v, field, fldName); e != nil {
+				return nil, e
 			}
-			nV.Elem().Set(vV.Convert(ft))
-			field.Set(nV.Elem().Addr())
 			continue
 		}
 
@@ -194,12 +232,30 @@ func DecodeInto(m map[string]interface{}, o interface{}, pf PathFactory) (interf
 		}
 		field.Set(reflect.ValueOf(v))
 	}
-	return o, nil
+
+	var err error
+	if applyDefaults {
+		err = setObjectDefaultValues(fm, vo)
+	}
+
+	return o, err
+}
+
+func assignPtrField(v interface{}, field reflect.Value, fldName string) error {
+	vV := reflect.ValueOf(v)
+	ft := reflect.TypeOf(field.Interface()).Elem()
+	nV := reflect.New(ft)
+	if !vV.Type().ConvertibleTo(ft) {
+		return parseAndSetField(fldName, field, nV, vV)
+	}
+	nV.Elem().Set(vV.Convert(ft))
+	field.Set(nV.Elem().Addr())
+	return nil
 }
 
 type iterator func() (next iterator, obj interface{})
 
-func decodeIntoArray(field reflect.Value, iter iterator, len int, pf PathFactory) error {
+func decodeIntoArray(field reflect.Value, iter iterator, len int, pf PathFactory, applyDefaults bool) error {
 	var s reflect.Value
 	var ps reflect.Value
 	var et reflect.Type
@@ -228,7 +284,7 @@ func decodeIntoArray(field reflect.Value, iter iterator, len int, pf PathFactory
 		objm, ok := o.(map[string]interface{})
 		if ok {
 			pV = reflect.New(et)
-			_, err := DecodeInto(objm, pV.Interface(), pf)
+			_, err := decodeInto(objm, pV.Interface(), pf, applyDefaults)
 			if err != nil {
 				return err
 			}
@@ -259,7 +315,7 @@ func decodeIntoArray(field reflect.Value, iter iterator, len int, pf PathFactory
 	return nil
 }
 
-func decodeIntoArrayOfObjectsField(field reflect.Value, fldName string, obj []map[string]interface{}, pf PathFactory) error {
+func decodeIntoArrayOfObjectsField(field reflect.Value, fldName string, obj []map[string]interface{}, pf PathFactory, applyDefaults bool) error {
 	n := 0
 	var i iterator
 	i = func() (iterator, interface{}) {
@@ -270,10 +326,10 @@ func decodeIntoArrayOfObjectsField(field reflect.Value, fldName string, obj []ma
 		return nil, nil
 	}
 
-	return decodeIntoArray(field, i, len(obj), pf)
+	return decodeIntoArray(field, i, len(obj), pf, applyDefaults)
 }
 
-func decodeIntoArrayField(field reflect.Value, fldName string, obj []interface{}, pf PathFactory) error {
+func decodeIntoArrayField(field reflect.Value, fldName string, obj []interface{}, pf PathFactory, applyDefaults bool) error {
 	n := 0
 	var i iterator
 	i = func() (iterator, interface{}) {
@@ -284,32 +340,30 @@ func decodeIntoArrayField(field reflect.Value, fldName string, obj []interface{}
 		return nil, nil
 	}
 
-	return decodeIntoArray(field, i, len(obj), pf)
+	return decodeIntoArray(field, i, len(obj), pf, applyDefaults)
 }
 
-func decodeIntoObjectField(field reflect.Value, _ string, v map[string]interface{}, pf PathFactory) error {
-	var pV interface{}
-
+func decodeIntoObjectField(field reflect.Value, _ string, v map[string]interface{}, pf PathFactory, applyDefaults bool) error {
+	ft := field.Type()
 	if field.Type().Kind() == reflect.Ptr {
-		pV = reflect.New(field.Type().Elem()).Interface()
-	} else {
-		pV = reflect.New(field.Type()).Interface()
+		ft = ft.Elem()
 	}
+	pV := reflect.New(ft).Interface()
 
-	child, err := DecodeInto(v, pV, pf)
+	child, err := decodeInto(v, pV, pf, applyDefaults)
 	if err != nil {
 		return err
 	}
+	cv := reflect.ValueOf(child)
 	if field.Kind() != reflect.Ptr {
-		field.Set(reflect.ValueOf(child).Elem())
-		return nil
+		cv = cv.Elem()
 	}
 
-	field.Set(reflect.ValueOf(child))
+	field.Set(cv)
 	return nil
 }
 
-func decodeIntoOneOfField(field reflect.Value, _ string, objSchemaName string, k string, v map[string]interface{}, pf PathFactory) (bool, error) {
+func decodeIntoOneOfField(field reflect.Value, _ string, objSchemaName string, k string, v map[string]interface{}, pf PathFactory, applyDefaults bool) (bool, error) {
 	var pp string
 	var f OneOfFactory
 	var child interface{}
@@ -326,7 +380,7 @@ func decodeIntoOneOfField(field reflect.Value, _ string, objSchemaName string, k
 		return false, err
 	}
 
-	if child, err = DecodeInto(v, child, pf); err == nil {
+	if child, err = decodeInto(v, child, pf, applyDefaults); err == nil {
 		field.Set(reflect.ValueOf(child))
 	}
 	return err == nil, err
@@ -337,26 +391,6 @@ func ptr(v reflect.Value) reflect.Value {
 	pv := reflect.New(pt.Elem())  // create a reflect.Value of type *T.
 	pv.Elem().Set(v)              // sets pv to point to underlying value of v.
 	return pv
-}
-
-// UnmarshalJSON byte description of a Decodeable thing
-func UnmarshalJSON(b []byte, discriminator string, f Factory) (interface{}, error) {
-	m := make(map[string]interface{})
-	err := json.Unmarshal(b, &m)
-	if err != nil {
-		return nil, err
-	}
-	return Decode(m, discriminator, f)
-}
-
-// UnmarshalJSON byte into an instance of object
-func UnmarshalJSONInto(b []byte, o interface{}, pf PathFactory) (interface{}, error) {
-	m := make(map[string]interface{})
-	err := json.Unmarshal(b, &m)
-	if err != nil {
-		return nil, err
-	}
-	return DecodeInto(m, o, pf)
 }
 
 func parseAndSetField(path string, field, newField, val reflect.Value) error {
@@ -377,4 +411,176 @@ func parseAndSetField(path string, field, newField, val reflect.Value) error {
 		return nil
 	}
 	return fmt.Errorf("cannot convert value (%v) to field '%s' type\n", val, path)
+}
+
+func setObjectDefaultValues(fm map[string]reflect.StructField, vo reflect.Value) error {
+	for k, v := range fm {
+		d, ok := v.Tag.Lookup(DefaultTagName)
+		if !ok {
+			continue
+		}
+		if err := setFieldDefaultValue(vo, k, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setFieldDefaultValue(vo reflect.Value, fn, dv string) (err error) {
+
+	f := vo.Elem().FieldByName(fn)
+	ft := f.Type()
+
+	if f.Kind() == reflect.Ptr {
+		ft = ft.Elem()
+	}
+	nV := reflect.New(ft)
+	dV := reflect.ValueOf(dv)
+	cv := vo
+
+	// Check that the field can be assigned from a default. We are supporting only:
+	// 1. types which reflect itself knows how to convert
+	// 2. types for which we have actual conversion from string
+	// 3. types for which Marshaller is defined and ban be used
+	if dV.Type().ConvertibleTo(ft) {
+		cv = dV.Convert(ft)
+	} else if convertibleFromString(ft) {
+		cv, err = convertFromString(ft, dv)
+	} else if isUnmarshallableField(f) {
+		cv, err = convertUnmarshallerField(fn, f, dV)
+	} else if unsupportedTypeForDefault(ft) {
+		err = fmt.Errorf("Field is not convertible: %s", fn)
+	}
+	if err != nil {
+		return err
+	}
+	nV.Elem().Set(cv)
+
+	if f.Kind() != reflect.Ptr {
+		nV = nV.Elem()
+	}
+	f.Set(nV)
+	return nil
+}
+
+func getUnmarshaller(field reflect.Value) json.Unmarshaler {
+	u, ok := field.Interface().(json.Unmarshaler)
+
+	// json.Unmarshal is typically only applicable to pointers, if this is not one, make one
+	if !ok && field.Kind() != reflect.Ptr {
+		field = ptr(field)
+		u, ok = field.Interface().(json.Unmarshaler)
+	}
+
+	return u
+}
+
+func isUnmarshallableField(field reflect.Value) bool {
+	return getUnmarshaller(field) != nil
+}
+
+func convertUnmarshallerField(path string, field, val reflect.Value) (vo reflect.Value, err error) {
+	// Defensive, since this is only called after a check to isUnmarshallerField.
+	u := getUnmarshaller(field)
+	if u == nil {
+		return vo, fmt.Errorf("cannot convert value (%v) to field '%s' type\n", val, path)
+	}
+	// marshal val back to []byte since it was converted to some underlying type (int/string)
+	vb, err := json.Marshal(val.Interface())
+	if err != nil {
+		return vo, fmt.Errorf("Cannot convert value to []byte when attempting to set '%s': %s\n", path, err)
+	}
+
+	// if the field is a pointer, we need to get to the underlying type
+	ft := field.Type()
+	if field.Kind() == reflect.Ptr {
+		ft = ft.Elem()
+	}
+	nV := reflect.New(ft)
+	u = nV.Interface().(json.Unmarshaler)
+
+	// unmarshal vb back into newField object via the unmarshaler
+	err = u.UnmarshalJSON(vb)
+	if err != nil {
+		return vo, fmt.Errorf("Cannot unmarshal byte values for field '%s': %s\n", path, err)
+	}
+
+	// peel off pointer if field is not a pointer
+	nV = nV.Elem()
+	//if field.Kind() != reflect.Ptr {
+	//}
+
+	// set field to the value unmarshaled into newField
+	return nV, nil
+}
+
+func convertibleFromString(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.Bool:
+		return true
+	}
+	return false
+}
+
+func unsupportedTypeForDefault(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Uintptr, reflect.Complex64, reflect.Complex128, reflect.Array, reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.Struct, reflect.UnsafePointer:
+		return true
+	}
+	return false
+}
+
+func convertFromString(t reflect.Type, v string) (vo reflect.Value, e error) {
+
+	if pc, ok := convMap[int(t.Kind())]; ok {
+		return rf(pc.cf(pc.pf(v, pc.sz)))
+	}
+	return vo, fmt.Errorf("Cannot convert string to unsupported field type: %s(%s)", t.Name(), t.Kind())
+
+}
+
+type pfn func(v string, sz int) (interface{}, error)
+type cfn func(interface{}, error) (interface{}, error)
+type pc struct {
+	sz int
+	pf pfn
+	cf cfn
+}
+
+var pf = func(v string, sz int) (interface{}, error) { return strconv.ParseFloat(v, sz) }
+var pi = func(v string, sz int) (interface{}, error) { return strconv.ParseInt(v, 0, sz) }
+var pui = func(v string, sz int) (interface{}, error) { return strconv.ParseUint(v, 0, sz) }
+var pb = func(v string, _ int) (interface{}, error) { return strconv.ParseBool(v) }
+var ci = func(v interface{}, e error) (interface{}, error) { return int(v.(int64)), e }
+var ci8 = func(v interface{}, e error) (interface{}, error) { return int8(v.(int64)), e }
+var ci16 = func(v interface{}, e error) (interface{}, error) { return int16(v.(int64)), e }
+var ci32 = func(v interface{}, e error) (interface{}, error) { return int32(v.(int64)), e }
+var ci64 = func(v interface{}, e error) (interface{}, error) { return v, e }
+var cui = func(v interface{}, e error) (interface{}, error) { return uint(v.(uint64)), e }
+var cui8 = func(v interface{}, e error) (interface{}, error) { return uint8(v.(uint64)), e }
+var cui16 = func(v interface{}, e error) (interface{}, error) { return uint16(v.(uint64)), e }
+var cui32 = func(v interface{}, e error) (interface{}, error) { return uint32(v.(uint64)), e }
+var cui64 = func(v interface{}, e error) (interface{}, error) { return v, e }
+var cf32 = func(v interface{}, e error) (interface{}, error) { return float32(v.(float64)), e }
+var cf64 = func(v interface{}, e error) (interface{}, error) { return v, e }
+var cb = func(v interface{}, e error) (interface{}, error) { return v, e }
+var rf = func(v interface{}, e error) (reflect.Value, error) { return reflect.ValueOf(v), e }
+
+var convMap = map[int]pc{
+	int(reflect.Int):     pc{0, pi, ci},
+	int(reflect.Int8):    pc{8, pi, ci8},
+	int(reflect.Int16):   pc{16, pi, ci16},
+	int(reflect.Int32):   pc{32, pi, ci32},
+	int(reflect.Int64):   pc{64, pi, ci64},
+	int(reflect.Uint):    pc{0, pui, cui},
+	int(reflect.Uint8):   pc{8, pui, cui8},
+	int(reflect.Uint16):  pc{16, pui, cui16},
+	int(reflect.Uint32):  pc{32, pui, cui32},
+	int(reflect.Uint64):  pc{64, pui, cui64},
+	int(reflect.Float32): pc{32, pf, cf32},
+	int(reflect.Float64): pc{64, pf, cf64},
+	int(reflect.Bool):    pc{0, pb, cb},
 }


### PR DESCRIPTION
added code to assign default values to decoded struct fields, if specified and not set in payload

Added DecodeIntoWithDefaults and UnmarshalIntoWithDefaults to allow this code to be opt in
This change also rearranges the code around so all public functions are up top and impls are below (leading to bigger diffs than they would otherwise be)